### PR TITLE
CS149: Update course link

### DIFF
--- a/docs/并行与分布式系统/CS149.md
+++ b/docs/并行与分布式系统/CS149.md
@@ -11,10 +11,10 @@
 
 
 ## 课程资源
-- 课程网站：[CMU15418](http://15418.courses.cs.cmu.edu/spring2016/)，[CS149](http://35.227.169.186/cs149/fall21)
+- 课程网站：[CMU15418](http://15418.courses.cs.cmu.edu/spring2016/)，[CS149](https://gfxcourses.stanford.edu/cs149/fall21)
 - [课程视频](http://15418.courses.cs.cmu.edu/spring2016/lectures)
 - 课程教材：无
-- [课程作业](http://35.227.169.186/cs149/fall21)：5个编程作业
+- [课程作业](https://gfxcourses.stanford.edu/cs149/fall21)：5个编程作业
 
 ## 资源汇总
 我在学习这门课中用到的所有资源和作业实现都汇总在[这个Github仓库](https://github.com/PKUFlyingPig/CS149-parallel-computing)中。


### PR DESCRIPTION
The old plain-IP link is returning a 301 redirect to the new location.