### PR TITLE
format issue at csdiy.wiki: duke coursera C markdown format fix.

### DIFF
--- a/docs/编程入门/Duke-Coursera-Intro-C.md
+++ b/docs/编程入门/Duke-Coursera-Intro-C.md
@@ -10,7 +10,7 @@
 
 ## 课程资源
 
-- 课程网站：[https://www.coursera.org/specializations/c-programming](https://www.coursera.org/specializations/c-programming)
+- 课程网站：<https://www.coursera.org/specializations/c-programming>
 - 课程视频：同上
 - 课程教材：同上
 - 课程作业：同上

--- a/docs/编程入门/Duke-Coursera-Intro-C.md
+++ b/docs/编程入门/Duke-Coursera-Intro-C.md
@@ -10,7 +10,7 @@
 
 ## 课程资源
 
-- 课程网站：https://www.coursera.org/specializations/c-programming
+- 课程网站：[https://www.coursera.org/specializations/c-programming](https://www.coursera.org/specializations/c-programming)
 - 课程视频：同上
 - 课程教材：同上
 - 课程作业：同上
@@ -20,12 +20,12 @@
 我在学习这门课中的作业实现都汇总在 [Duke Coursera Intro C](https://code.haidongji.com/Duke_Coursera_Intro_C/) 中。因为时间关系，我最后一课最后一周的几个作业到目前还没有完成。
 
 ## 备注
-
 非常好的课程，自我感觉收益非常大：
+
 - 侧重基础和科学方法论。C（C++）基本概念如frame、stack memory、heap memory等讲得很透
 - 针对C最难掌握的指针，有好的练习和编程会强化和加深理解
 - 非常好的gdb、valgrind上手训练。如果你没用过git，作业会给你一些基本的git练习
 - 老师建议作业用Emacs。所以对Emacs小白来说，是个不错的入门。如果你会用Vim，我建议你用Evil插件。这样Emacs感觉起来像Vim:你不会丢掉Vim强大的编辑功能，同时你可以体会Emacs的强大，很可能入坑。这不是坏事，工具箱里同时有Emacs和Vim时，效率会有不少提高。Emacs的org-mode，和gdb的顺滑整合，等等等等，都会让你如虎添翼。
 - 虽然可能需要付钱，我觉得值
--Coursera把这一大课分成了四个小课，但小课之间的作业文件的转移并不顺利。这是个有点讨厌的地方。幸运的是，后面的小课可以给以前小课的作业打分，所以我是接着把前面的作业又做了一遍。权当巩固，效果不错。
+- Coursera把这一大课分成了四个小课，但小课之间的作业文件的转移并不顺利。这是个有点讨厌的地方。幸运的是，后面的小课可以给以前小课的作业打分，所以我是接着把前面的作业又做了一遍。权当巩固，效果不错。
 - 虽说课名是入门，感觉还挺有深度和挺全面的，能增加你C/C++编程信心。


### PR DESCRIPTION
Thanks for the approval of my previous PR!

I found 2 display issues at csdiy.wiki. I'm hopeful that this PR will fix it:

- The hyperlink of course URL is plain text and not clickable
- Comment section should have been a list.