### PR TITLE
[ENHANCE] Add assignment code/note link to course MIT 6.031: Software Construction

### DIFF
--- a/docs/软件工程/6031.md
+++ b/docs/软件工程/6031.md
@@ -30,3 +30,5 @@
 ## 资源汇总
 
 我在学习这门课中用到的所有资源和作业实现都汇总在 [PKUFlyingPig/MIT6.031-software-construction - GitHub](https://github.com/PKUFlyingPig/MIT6.031-software-construction) 中。
+
+@pengzhangzhi完成了这门课的作业并记录了笔记。代码开源在[self-taught-CS/Software Construction at main · pengzhangzhi/self-taught-CS (github.com)](https://github.com/pengzhangzhi/self-taught-CS/tree/main/Software Construction)。


### PR DESCRIPTION
我把MIT 6.031: Software Construction lab 实现代码放在https://github.com/pengzhangzhi/self-taught-CS/tree/main/Software%20Construction
感兴趣的话可以引用下。
see this issue https://github.com/PKUFlyingPig/cs-self-learning/issues/211