### PR TITLE
[FIX]: 替换失效的《动手学深度学习》的链接

### DIFF
--- a/docs/好书推荐.md
+++ b/docs/好书推荐.md
@@ -113,7 +113,7 @@
 
 ## 深度学习
 
-- [动手学深度学习](http://tangshusen.me/Dive-into-DL-PyTorch/#/) [[豆瓣](https://book.douban.com/subject/33450010/)]
+- [动手学深度学习](https://zh.d2l.ai) [[豆瓣](https://book.douban.com/subject/33450010/)]
 - [神经网络与深度学习](https://nndl.github.io/) [[豆瓣](https://book.douban.com/subject/35044046/)]
 - 深度学习入门 [[豆瓣](https://book.douban.com/subject/30270959/)]
 - [简单粗暴 TensorFlow 2 (Tutorial)](https://tf.wiki/)


### PR DESCRIPTION
fix: 替换失效的《动手学深度学习》的链接