### PR TITLE
[TRANSLATE] Translate Stanford's Compiler Course 

### DIFF
--- a/docs/编译原理/CS143.en.md
+++ b/docs/编译原理/CS143.en.md
@@ -8,16 +8,16 @@
 - Difficulty: 🌟🌟🌟🌟🌟
 - Learning Hours: 150
 
-All this course intends is imparting principles of compiler construction for programming languages to students. Instructors has designed a “COOL language”, namely Class-Object-Oriented-Language, and you are expected to build a compiler for it. By study and practice, you will acquire the ability to design a appropriate compiler, which can translate human-readable COOL into “computer-readable” MIPS assembly being running on the SPIM emulator.
+This course aims to impart the principles of compiler construction for programming languages to students. The instructors have designed a “COOL language”, namely Class-Object-Oriented-Language. By study and practice, you will design and implement a compiler, which can translate the human-readable COOL language into machine-readable MIPS assembly which can be run on the SPIM emulator.
 
-Following the Dragon Book, the theoretical part covers lexical analysis, syntax analysis, semantics analysis, runtime environments, register allocation, optimization and code generation. The practical part, accordingly, is divided in four modules: 3 for different steps of analysis and 1 for code generation. The difficulty is considered gradual, increasing with a proper rate. Should you have enough capacity and interest even after taking all those regular path, there’s a huge room left for you to do optimization.
+Following the Dragon Book, the theoretical part of the course covers lexical analysis, syntax analysis, semantics analysis, runtime environments, register allocation, optimization, and code generation. The practical part, accordingly, is divided into 4 steps: 3 for the frontend and 1 for the backend. The difficulty is considered gradual, increasing at a proper rate. Should you have enough time and interest even after completing all the required work, there’s a huge room left for you to do optimization.
 
 ## Course Resources
 
 - Course Website: <http://web.stanford.edu/class/cs143/>
 - Recordings: <https://www.bilibili.com/video/BV17K4y147Bz>
 - Textbook: Compilers: Principles, Techniques and Tools (Dragon Book)
-- Assignments: 5 textual + 5 programming labs
+- Assignments: 5 written assignments + 5 programming labs
 
 ## Collection of Course Resources
 

--- a/docs/编译原理/CS143.en.md
+++ b/docs/编译原理/CS143.en.md
@@ -1,0 +1,24 @@
+# Stanford CS143: Compilers
+
+## Descriptions
+
+- Offered by: Stanford University
+- Prerequisite: Computer Architecture
+- Programming Languages: Java or C++
+- Difficulty: 🌟🌟🌟🌟🌟
+- Learning Hours: 150
+
+All this course intends is imparting principles of compiler construction for programming languages to students. Instructors has designed a “COOL language”, namely Class-Object-Oriented-Language, and you are expected to build a compiler for it. By study and practice, you will acquire the ability to design a appropriate compiler, which can translate human-readable COOL into “computer-readable” MIPS assembly being running on the SPIM emulator.
+
+Following the Dragon Book, the theoretical part covers lexical analysis, syntax analysis, semantics analysis, runtime environments, register allocation, optimization and code generation. The practical part, accordingly, is divided in four modules: 3 for different steps of analysis and 1 for code generation. The difficulty is considered gradual, increasing with a proper rate. Should you have enough capacity and interest even after taking all those regular path, there’s a huge room left for you to do optimization.
+
+## Course Resources
+
+- Course Website: <http://web.stanford.edu/class/cs143/>
+- Recordings: <https://www.bilibili.com/video/BV17K4y147Bz>
+- Textbook: Compilers: Principles, Techniques and Tools (Dragon Book)
+- Assignments: 5 textual + 5 programming labs
+
+## Collection of Course Resources
+
+@skyzluo has been maintaining a repo of course resources used and reference implementations of programming labs: [skyzluo/CS143-Compilers-Stanford - GitHub](https://github.com/skyzluo/CS143-Compilers-Stanford).


### PR DESCRIPTION
本 PR 中包含新增的对 Stanford CS 143 课程介绍的翻译。
第 19 行处连续出现引号是否不自然存疑：本人不确定叙述书名的合理格式（例如是否使用引号或半角书名号等），愿对此熟悉的各位不吝赐教。