### PR TITLE
[UPDATE]Add new course link for CS50

### DIFF
--- a/docs/编程入门/CS50.en.md
+++ b/docs/编程入门/CS50.en.md
@@ -12,6 +12,6 @@ This course has been voted the most popular public course by Harvard students fo
 
 ## Course Resources
 
-- Course Website: <https://cs50.harvard.edu/x/2022/>
-- Recordings: <https://cs50.harvard.edu/x/2022/>
-- Assignments: <https://cs50.harvard.edu/x/2022/>
+- Course Website: [2022](https://cs50.harvard.edu/x/2022/), [2023](https://cs50.harvard.edu/x/2023/)
+- Recordings: [2022](https://cs50.harvard.edu/x/2022/), [2023](https://cs50.harvard.edu/x/2023/)
+- Assignments: [2022](https://cs50.harvard.edu/x/2022/), [2023](https://cs50.harvard.edu/x/2023/)

--- a/docs/编程入门/CS50.md
+++ b/docs/编程入门/CS50.md
@@ -12,7 +12,7 @@
 
 ## 课程资源
 
-- 课程网站：<https://cs50.harvard.edu/x/2022/>
-- 课程视频：<https://cs50.harvard.edu/x/2022/>
+- 课程网站：<https://cs50.harvard.edu/x/2023/>
+- 课程视频：<https://cs50.harvard.edu/x/2023/>
 - 课程教材：无
-- 课程作业：<https://cs50.harvard.edu/x/2022/>
+- 课程作业：<https://cs50.harvard.edu/x/2023/>

--- a/docs/编程入门/CS50.md
+++ b/docs/编程入门/CS50.md
@@ -12,7 +12,7 @@
 
 ## 课程资源
 
-- 课程网站：<https://cs50.harvard.edu/x/2023/>
-- 课程视频：<https://cs50.harvard.edu/x/2023/>
+- 课程网站：[2022](https://cs50.harvard.edu/x/2022/), [2023](https://cs50.harvard.edu/x/2023/)
+- 课程视频：[2022](https://cs50.harvard.edu/x/2022/), [2023](https://cs50.harvard.edu/x/2023/)
 - 课程教材：无
-- 课程作业：<https://cs50.harvard.edu/x/2023/>
+- 课程作业：[2022](https://cs50.harvard.edu/x/2022/), [2023](https://cs50.harvard.edu/x/2023/)


### PR DESCRIPTION
Lastest link of this course: https://cs50.harvard.edu/x/2023/#how-to-take-this-course