### PR TITLE
[ENHANCE] Fix prerequisites of Data 100.

### DIFF
--- a/docs/数据科学/Data100.en.md
+++ b/docs/数据科学/Data100.en.md
@@ -3,7 +3,7 @@
 ## Description
 
 - Offered by: UC Berkeley
-- Prerequisites: CS61A, Linear Algebra
+- Prerequisites: Data 8, CS61A, Linear Algebra
 - Programming Languages: Python
 - Difficulty: 🌟🌟🌟
 - Class Hour: 80 hours
@@ -11,7 +11,7 @@
 This is Berkeley's introductory course in data science, covering the basics of data cleaning, feature extraction, data visualization, machine learning and inference, as well as common data science tools such as Pandas, Numpy, and Matplotlib. The course is also rich in interesting programming assignments, which is one of the highlights of the course.
 
 ## Resources
-- Course Website: <https://ds100.org/fa21/>
+- Course Website: <https://ds100.org>
 - Records: refer to the course website
 - Textbook: <https://www.textbook.ds100.org/intro.html>
 - Assignments: refer to the course website

--- a/docs/数据科学/Data100.en.md
+++ b/docs/数据科学/Data100.en.md
@@ -3,7 +3,7 @@
 ## Description
 
 - Offered by: UC Berkeley
-- Prerequisites: Data 8, CS61A, Linear Algebra
+- Prerequisites: Data8, CS61A, Linear Algebra
 - Programming Languages: Python
 - Difficulty: 🌟🌟🌟
 - Class Hour: 80 hours

--- a/docs/数据科学/Data100.md
+++ b/docs/数据科学/Data100.md
@@ -3,7 +3,7 @@
 ## 课程简介
 
 - 所属大学：UC Berkeley
-- 先修要求：CS61A，线性代数
+- 先修要求：Data8, CS61A，线性代数
 - 编程语言：Python
 - 课程难度：🌟🌟🌟
 - 预计学时：80 小时
@@ -12,7 +12,7 @@
 
 ## 课程资源
 
-- 课程网站：<https://ds100.org/fa21/>
+- 课程网站：<https://ds100.org/>
 - 课程视频：参见课程网站
 - 课程教材：<https://www.textbook.ds100.org/intro.html>
 - 课程作业：参见课程网站


### PR DESCRIPTION
[Prerequisites here](https://ds100.org/)

原文如下：

While we are working to make this class widely accessible we currently require the following (or equivalent) prerequisites:

Foundations of Data Science: [Data 8](http://data8.org/) covers much of the material in Data 100 but at an introductory level. Data8 provides basic exposure to python programming and working with tabular data as well as visualization, statistics, and machine learning.

Computing: The Structure and Interpretation of Computer Programs [CS 61A](http://cs61a.org/) or Computational Structures in Data Science [CS 88](http://cs88-website.github.io/). These courses provide additional background in python programming (e.g., for loops, lambdas, debugging, and complexity) that will enable Data 100 to focus more on the concepts in Data Science and less on the details of programming in python.

Math: Linear Algebra ([Math 54](https://math.berkeley.edu/~nadler/54fall2017.html), [EE 16A](http://inst.eecs.berkeley.edu/~ee16a/), or [Stat 89A](https://stat89a.com/)): We will need some basic concepts like linear operators and derivatives to enable statistical inference and derive new prediction algorithms. This may be satisfied concurrently to Data 100.