### PR TITLE
add markdown extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ theme:
 markdown_extensions:
   - attr_list
   - md_in_html
+  - footnotes
 
 plugins:
   - i18n:
@@ -182,7 +183,6 @@ nav:
       - "MIT 6.S081: Operating System Engineering": "操作系统/MIT6.S081.md"
       - "UCB CS162: Operating System": "操作系统/CS162.md"
       - "NJU OS: Operating System Design and Implementation": "操作系统/NJUOS.md"
-      - "HIT OS: Operating System": "操作系统/HITOS.md"
   - 并行与分布式系统:
       - "CMU 15-418/Stanford CS149: Parallel Computing": "并行与分布式系统/CS149.md"
       - "MIT 6.824: Distributed System": "并行与分布式系统/MIT6.824.md"
@@ -213,7 +213,6 @@ nav:
       - "MIT web development course": "Web开发/mitweb.md"
       - "Stanford CS142: Web Applications": "Web开发/CS142.md"
       - "University of Helsinki: Full Stack open 2022": "Web开发/fullstackopen.md"
-      - "CS571 Building UI (React & React Native)": "Web开发/CS571.md"
   - 数据科学:
       - "UCB Data100: Principles and Techniques of Data Science": "数据科学/Data100.md"
   - 人工智能:


### PR DESCRIPTION
I noticed footnotes extension didn't add in mkdocs.yml.  so in "必学工具/信息检索" the footnote didn't render correctly, I read the [reference site](https://squidfunk.github.io/mkdocs-material/reference/footnotes/ ) of the material for mkdocs coincidentally.   
and this is my first pull request, don't care my poor English. at last, thanks for your contribution to the internet.  
I hope I can be much more better though your tutorial of cs-self-learning although I am just a 菜鸟 learning MIT-missing-semester