### PR TITLE
[CONFIG] Add footnotes markdown extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ theme:
 markdown_extensions:
   - attr_list
   - md_in_html
+  - footnotes
 
 plugins:
   - i18n:


### PR DESCRIPTION
I noticed footnotes extension didn't add in mkdocs.yml, so in "必学工具/信息检索" the footnote didn't render correctly. I read the [reference site](https://squidfunk.github.io/mkdocs-material/reference/footnotes/) of the material for mkdocs coincidentally.  
and this is my first pull request. I quote a word from TED's presenter to linus torvalds  
>  ***thanks for your contribution to the internet***  

上一次发起pull request 的时候我犯了个错误，就是本地的仓库还停留在老版本上，结果发起pull request 后才注意到对其他地方有些许改动,不得不关闭了那个pull request. 为了避免我的第一次pull request 的commit 留在 git log --all --graph的历史耻辱柱上，我做了一些新手都会做的事情。[missing semester 上那幅漫画](https://xkcd.com/1597/)