### PR TITLE
[FIX] fix zlibrary link

### DIFF
--- a/docs/必学工具/tools.md
+++ b/docs/必学工具/tools.md
@@ -4,7 +4,7 @@
 
 - [Sci-Hub](https://sci-hub.se/): Elbakyan 女神向你挥手，旨在打破知识壁垒的革命性网站。
 - [Library Genesis](http://libgen.is/): 电子书下载网站。
-- [Z-library](https://z-lib.is/): 电子书下载网站（在 [Tor](https://www.torproject.org/) 下运行较佳，[链接](http://loginzlib2vrak5zzpcocc3ouizykn6k5qecgj2tzlnab5wcbqhembyd.onion/)）。
+- [Z-library](https://zlibrary-global.se/): 电子书下载网站（在 [Tor](https://www.torproject.org/) 下运行较佳，[链接](http://loginzlib2vrak5zzpcocc3ouizykn6k5qecgj2tzlnab5wcbqhembyd.onion/)）。
 - [Z-ePub](https://z-epub.com/): ePub 电子书下载网站。
 - [PDF Drive](https://www.pdfdrive.com/): PDF 电子书搜索引擎。
 - [MagazineLib](https://magazinelib.com/): PDF 电子杂志下载网站。


### PR DESCRIPTION
Z-Library 官网专门警示了非官方链接：

![image](https://github.com/PKUFlyingPig/cs-self-learning/assets/104191582/095a2e00-67d4-4a65-bada-c51bee5f5efb)

因此还是修改更新一下。

[Z-Library – the world’s largest e-book library. Your gateway to knowledge and culture.](https://zlibrary-global.se/)