### PR TITLE
[COURSE] Add UMich EECS 498-007: Deep Learning for Computer Vision

### DIFF
--- a/docs/CS学习规划.md
+++ b/docs/CS学习规划.md
@@ -326,6 +326,8 @@ Berkeley 作为著名开源数据库 postgres 的发源地也不遑多让，[UCB
 
 #### 计算机视觉
 
+[UMich EECS 498-007 / 598-005: Deep Learning for Computer Vision](深度学习/EECS498-007.md)
+
 [Stanford CS231n: CNN for Visual Recognition](深度学习/CS231.md)
 
 #### 自然语言处理

--- a/docs/深度学习/EECS498-007.en.md
+++ b/docs/深度学习/EECS498-007.en.md
@@ -1,0 +1,60 @@
+# UMich EECS 498-007 / 598-005: Deep Learning for Computer Vision
+
+## Course Introduction
+
+- Offered by: UMich
+- Prerequisites: Basic Python, Matrix Theory (familiarity with matrix derivation is sufficient), Calculus
+- Programming Languages: Python
+- Difficulty: 🌟🌟🌟🌟
+- Class Hour: 60 ~ 80 hours
+
+The University of Michigan's Computer Vision course is of exceptionally high quality, with its videos and assignments covering an extensive range of topics. 
+
+The assignments gradually increase in difficulty and cover all stages of mainstream CV model development, making this an excellent introductory course for Computer Vision.
+
+In each assignment, you'll build and train models or frameworks mentioned in the lectures, following the provided handouts.
+
+You don't need any prior experience with deep learning frameworks. 
+
+The course will teach you from scratch how to use Pytorch in the early assignments, and it can subsequently serve as a reference book for you.
+
+As each assignment deals with different themes, you'll not only gain a first-hand understanding of the development of mainstream CV models through these progressive assignments but also appreciate the impacts of different models and training methods on final performance and accuracy. 
+
+Moreover, you'll get hands-on experience in implementing them.
+
+In Assignment 1 (A1), you'll learn how to use Pytorch and Google Colab.
+
+In Assignment 2 (A2), you will build a Linear Classifier and a two-layer neural network. Finally, you'll have the opportunity to work with the MNIST dataset, on which you will train and evaluate your neural network.
+
+In Assignment 3 (A3), you'll encounter the classic Convolutional Neural Network (CNN) and experience the power of convolutional neural networks.
+
+In Assignment 4 (A4), you'll have the opportunity to build an object detection model from scratch, following the handout to implement a One-Stage Detector and a Two-Stage Detector from two research papers.
+
+By Assignment 5 (A5), you'll transition from CNN to RNN. You'll have the opportunity to build two different attention-based models, RNNs (Vanilla RNN & LSTM), and the famous Transformer.
+
+In the final assignment (A6), you'll get a chance to implement two more advanced models, VAE and GAN, and apply them to the MNIST dataset. Finally, you'll implement two very cool features: network visualization and style transfer.
+
+Beyond the assignments, you can also implement a Mini-Project, building a complete deep learning pipeline. You can refer to the course homepage for specifics.
+
+All the resources involved in the course, such as lectures, notes, and assignments, are open source. 
+
+The only downside is that the Autograder is only available to students enrolled at the University of Michigan. 
+
+However, given that the correctness of the implementation and the expected results can already be confirmed in the provided *.ipynb (i.e., the Handout), I personally feel that the absence of Autograder doesn't affect the learning process.
+
+It's worth mentioning that the main lecturer for this course, Justin Johnson, is a Ph.D. graduate of Fei-Fei Li and currently an Assistant Professor at the University of Michigan.
+
+The open-source 2017 version of Stanford's CS231N was taught by Justin Johnson.
+
+Because CS231N was mainly developed by Justin Johnson and Andrej Karpathy, this course also adopts some materials from CS231N. 
+
+Therefore, students who have studied CS231N might find some materials in this course familiar.
+
+Lastly, I recommend every student enrolled in this course to watch the lectures on YouTube. Justin Johnson's teaching style and content are very clear and easy to understand, making them a fantastic resource.
+
+## Course Resources
+
+- Course Website：<https://web.eecs.umich.edu/~justincj/teaching/eecs498/WI2022/>
+- Course Video：<https://www.youtube.com/playlist?list=PL5-TkQAfAZFbzxjBHtzdVCWE0Zbhomg7r>
+- Course Materials: Only recommended textbooks, link: <https://www.deeplearningbook.org/>
+- Coursework：See the course homepage for details, six Assignments and one Mini-Project

--- a/docs/深度学习/EECS498-007.md
+++ b/docs/深度学习/EECS498-007.md
@@ -1,4 +1,4 @@
-# EECS 498-007 / 598-005: Deep Learning for Computer Vision
+# UMich EECS 498-007 / 598-005: Deep Learning for Computer Vision
 
 ## 课程简介
 
@@ -24,11 +24,11 @@ UMich 的 Computer Vision 课，课程视频和作业质量极高，涵盖的主
 
 而在 A4 中，你将实际触及搭建物体检测模型的全流程，同时跟随 Handout 实现两篇论文中的 One-Stage Detector 和 Two-Stage Detector。
 
-到了 A5，就是从 CNN 到 RNN 的时刻了，你将有机会亲自搭建起两种不同的基于注意力的模型，RNN 和大名鼎鼎的 Transfomer。
+到了 A5，就是从 CNN 到 RNN 的时刻了，你将有机会亲自搭建起两种不同的基于注意力的模型，RNNs (Vanilla RNN & LSTM) 和大名鼎鼎的 Transfomer。
 
-在最后一个 Assignment（A6）中，你将有机会实现两种更为 Fancy 的模型，VAE 和 GAN，并应用在 MINST 数据集上。最后，你会实现网络可视化和风格迁移两个非常酷炫的功能。
+在最后一个 Assignment（A6）中，你将有机会实现两种更为 Fancy 的模型，VAE 和 GAN，并应用在 MINST 数据集上。最后，你会实现网络可视化和风格迁移这两个非常酷炫的功能。
 
-在 Assignments 之外，你还可以自己实现一个 mini-project，亲自搭建起一个完整的深度学习 Pipeline，具体可以参考课程主页。
+在 Assignments 之外，你还可以自己实现一个 Mini-Project，亲自搭建起一个完整的深度学习 Pipeline，具体可以参考课程主页。
 
 课程所涉及的资源，如 Lectures/Notes/Assignments 都是开源的，美中不足的是 Autograder 只对本校 Enrolled 的学生开放，但因为在提供的 `*.ipynb`（也就是 Handout） 中已经可以确定实现的正确性，以及预期的结果，所以我个人觉得 Autograder 的缺失没有任何影响。
 

--- a/docs/深度学习/EECS498-007.md
+++ b/docs/深度学习/EECS498-007.md
@@ -1,0 +1,48 @@
+# EECS 498-007 / 598-005: Deep Learning for Computer Vision
+
+## 课程简介
+
+- 所属大学：UMich
+- 先修要求：Python基础，矩阵论(熟悉矩阵求导即可)，微积分
+- 编程语言：Python
+- 课程难度：🌟🌟🌟🌟
+- 预计学时：60～80 小时
+
+UMich 的 Computer Vision 课，课程视频和作业质量极高，涵盖的主题非常全，同时 Assignments 的难度由浅及深，覆盖了 CV 主流模型发展的全阶段，是一门非常好的 Computer Vision 入门课。
+
+你在每个 Assignment 里会跟随 Handouts 搭建与训练 Lectures 中提到的模型/框架。
+
+你不需要有任何的深度学习框架的使用经验，在开始的 Assignment 里，这门课会从零开始教导每个学生如何使用 Pytorch，后续也可以当成工具书，随时翻阅。
+
+同时由于每个 Assignment 之间涉及到的主题都不同，你在递进式的 Assignment 中不仅可以亲身体会到 CV 主流模型的发展历程，领略到不同的模型和训练的方法对最终效果/准确率的影响，同时也能 Hands On 地实现它们。
+
+在 A1 中，你会学习 Pytorch 和 Google Colab 的使用。
+
+在 A2 中你会亲自搭建 Linear Classifier 以及一个两层的神经网络，最后你有机会亲自接触 MNIST 数据集并在此基础上训练并评估你搭建起的神经网络。
+
+在 A3 中，你会接触到最为经典的 Convolutional Neural Network (A.K.A. CNN)，亲自感受卷积神经网络的魅力。
+
+而在 A4 中，你将实际触及搭建物体检测模型的全流程，同时跟随 Handout 实现两篇论文中的 One-Stage Detector 和 Two-Stage Detector。
+
+到了 A5，就是从 CNN 到 RNN 的时刻了，你将有机会亲自搭建起两种不同的基于注意力的模型，RNN 和大名鼎鼎的 Transfomer。
+
+在最后一个 Assignment（A6）中，你将有机会实现两种更为 Fancy 的模型，VAE 和 GAN，并应用在 MINST 数据集上。最后，你会实现网络可视化和风格迁移两个非常酷炫的功能。
+
+在 Assignments 之外，你还可以自己实现一个 mini-project，亲自搭建起一个完整的深度学习 Pipeline，具体可以参考课程主页。
+
+课程所涉及的资源，如 Lectures/Notes/Assignments 都是开源的，美中不足的是 Autograder 只对本校 Enrolled 的学生开放，但因为在提供的 `*.ipynb`（也就是 Handout） 中已经可以确定实现的正确性，以及预期的结果，所以我个人觉得 Autograder 的缺失没有任何影响。
+
+值得一提的是，这门课的主讲教授 Justin Johnson 正是 Fei-Fei Li 的博士毕业生，现在在 UMich 当 Assistant Professor。
+
+而现在开源的 2017 年版本的 Stanford CS231N 的主讲人就是 Justin Johnson。
+
+同时因为 CS231N 主要是由 Justin Johnson 和 Andrej Karpathy 建设起来的，这门课也沿用了 CS231N 的一些材料，所以学过 CS231N 的同学可能会觉得这门课的某些材料比较熟悉。
+
+最后，我推荐每一个 Enroll 这门课的同学都去看一看 Youtube 上面的 Lectures，Justin Johnson 的讲课方式和内容都非常清晰和易懂，是非常棒的参考。
+
+## 课程资源
+
+- 课程网站：<https://web.eecs.umich.edu/~justincj/teaching/eecs498/WI2022/>
+- 课程视频：<https://www.youtube.com/playlist?list=PL5-TkQAfAZFbzxjBHtzdVCWE0Zbhomg7r>
+- 课程教材：仅有推荐教材，链接：<https://www.deeplearningbook.org/>
+- 课程作业：见课程主页，6 个 Assignment 和一个 Mini-Project

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -230,6 +230,7 @@ nav:
       - "CMU 10-414/714: Deep Learning Systems": "机器学习系统/CMU10-414.md"
       - "Machine Learning Compilation": "机器学习系统/MLC.md"
   - 深度学习:
+      - "UMich EECS 498-007 / 598-005: Deep Learning for Computer Vision": "深度学习/EECS498-007.md"
       - "Coursera: Deep Learning": "深度学习/CS230.md"
       - "国立台湾大学：李宏毅机器学习": "深度学习/LHY.md"
       - "Stanford CS231n: CNN for Visual Recognition": "深度学习/CS231.md"


### PR DESCRIPTION
This PR introduces the addition of the computer vision course `EECS 498-007` offered by the University of Michigan (UMich), taught by Justin Johnson.

To mention, Justin Johnson is also the main contributor and maintainer of course `CS231N` when he's still pursuing his Ph.D. in Stanford.

Designed with beginners in mind, `EECS 498-007` serves as an excellent resource and hands-on practice for those new to computer vision. The course does not require extensive prerequisites, making it accessible for a wide range of students.

I highly recommend this course to any student harboring an interest in computer vision. Your journey into this fascinating field could very well start here.