### PR TITLE
[UPDATE] Add links to CS50x videos with Chinese subtitles, and a shared document with course resources.

### DIFF
--- a/docs/编程入门/CS50.md
+++ b/docs/编程入门/CS50.md
@@ -14,9 +14,13 @@
 
 - 课程网站：[2022](https://cs50.harvard.edu/x/2022/), [2023](https://cs50.harvard.edu/x/2023/)
 - 课程视频：[2022](https://cs50.harvard.edu/x/2022/), [2023](https://cs50.harvard.edu/x/2023/)
+- 课程中文字幕视频：
+    - figuretu（未完结）：[合集：CS50x - Lectures](https://space.bilibili.com/398793142/channel/collectiondetail?sid=1694108)
 - 课程教材：无
 - 课程作业：[2022](https://cs50.harvard.edu/x/2022/), [2023](https://cs50.harvard.edu/x/2023/)
 
 ## 资源汇总
 
 @mancuoj 在学习这门课中用到的所有资源和作业实现都汇总在 [mancuoj/CS50x - GitHub](https://github.com/mancuoj/CS50x) 中。
+
+@figuretu 整理有价值的提问讨论、相关学习资源在共享文档 [CS50 - 资源总目录](https://uufyjevghz.feishu.cn/docx/DP78d2U5TosTOTx9QCbcjp8GnBh) 中。


### PR DESCRIPTION
课程仍在持续翻译中，C 语言部分翻译 23 年版本，还有两课结束，之后课程翻译 24 年新版；因为初学者的问题大多相似，维护一个共享文档进行收录和资料整理。个人翻译，无盈利计划。