### PR TITLE
[FIX] Fix text book link for CS61A

### DIFF
--- a/docs/编程入门/CS61A.en.md
+++ b/docs/编程入门/CS61A.en.md
@@ -26,7 +26,7 @@ Note: If you have no prior programming experience at all, getting started with C
 
 - Course Website: <https://inst.eecs.berkeley.edu/~cs61a/su20/>
 - Recordings: refer to the course website
-- Textbook: <http://composingprograms.com/>
+- Textbook: <https://www.composingprograms.com/>
 - Assignments: refer to the course website
 
 ## Personal Resources

--- a/docs/编程入门/CS61A.md
+++ b/docs/编程入门/CS61A.md
@@ -26,7 +26,7 @@ CS61B 和 CS61C 在本书中均有收录。
 
 - 课程网站：<https://inst.eecs.berkeley.edu/~cs61a/su20/>
 - 课程视频: 参见课程网站链接
-- 课程教材：<http://composingprograms.com/>
+- 课程教材：<https://www.composingprograms.com/>
 - 课程教材中文翻译：<https://composingprograms.netlify.app/>
 - 课程作业：课程网站会有每个作业对应的文档链接以及代码框架的下载链接。
 


### PR DESCRIPTION
Update the URL to text book. The original link no longer work.