### PR TITLE
[FIX] Fix course link for NJU OS

### DIFF
--- a/docs/操作系统/NJUOS.md
+++ b/docs/操作系统/NJUOS.md
@@ -20,10 +20,10 @@
 
 ## 课程资源
 
-- 课程网站：<http://jyywiki.cn/OS/2022/>
+- 课程网站：<https://jyywiki.cn/OS/2022/index.html>
 - 课程视频：<https://space.bilibili.com/202224425/channel/collectiondetail?sid=192498>
 - 课程教材：<http://pages.cs.wisc.edu/~remzi/OSTEP/>
-- 课程作业：<http://jyywiki.cn/OS/2022/>
+- 课程作业：<https://jyywiki.cn/OS/2022/index.html>
 
 ## 资源汇总
 


### PR DESCRIPTION
<img width="1094" alt="image" src="https://github.com/PKUFlyingPig/cs-self-learning/assets/38343778/e7905f45-3560-4275-94cd-b6594b3bb2a5">

原来的链接现在返回 404 了