### PR TITLE
[FIX] Fix blog link for MIT 6.S081

### DIFF
--- a/docs/操作系统/MIT6.S081.en.md
+++ b/docs/操作系统/MIT6.S081.en.md
@@ -46,7 +46,7 @@ All resources used and assignments implemented by @PKUFlyingPig when learning th
 ### Some Blogs for References
 
 - [doraemonzzz](http://doraemonzzz.com/tags/6-S081/)
-- [Xiao Fan (樊潇)](https://fanxiao.tech/posts/MIT-6S081-notes/)
+- [Xiao Fan (樊潇)](https://fanxiao.tech/posts/2021-03-02-mit-6s081-notes/)
 - [Miigon's blog](https://blog.miigon.net/categories/mit6-s081/)
 - [Zhou Fang](https://walkerzf.github.io/categories/6-S081/index.html)
 - [Yichun's Blog](https://www.yichuny.page/tags/Operating%20System)

--- a/docs/操作系统/MIT6.S081.md
+++ b/docs/操作系统/MIT6.S081.md
@@ -46,7 +46,7 @@
 ### 一些可以参考的博客
 
 - [doraemonzzz](http://doraemonzzz.com/tags/6-S081/)
-- [Xiao Fan (樊潇)](https://fanxiao.tech/posts/MIT-6S081-notes/)
+- [Xiao Fan (樊潇)](https://fanxiao.tech/posts/2021-03-02-mit-6s081-notes/)
 - [Miigon's blog](https://blog.miigon.net/categories/mit6-s081/)
 - [Zhou Fang](https://walkerzf.github.io/categories/6-S081/index.html)
 - [Yichun's Blog](https://www.yichuny.page/tags/Operating%20System)


### PR DESCRIPTION
原 Xiao Fan (樊潇) 博客链接现在返回 404，更新为新的地址.