### PR TITLE
Add Stanford CS110: Principle of Computer Systems

### DIFF
--- a/docs/操作系统/CS110.en.md
+++ b/docs/操作系统/CS110.en.md
@@ -1,0 +1,25 @@
+# CS110: Principles of Computer Systems
+
+## Descriptions
+
+- Offered by: Stanford
+- Prerequisites:  The course builds upon CS107 and requires good knowledge of C, C++, Unix, GDB, Valgrind, and Make. Students should be able to write moderately complex programs, read and understand portions of large code bases, trace memory diagrams, and be fluent with Unix, GDB, Valgrind, and Make
+- Programming Languages: C, C++
+- Difficulty: 🌟🌟🌟🌟🌟
+- Class Hour: 150 hours
+
+This course builds upon the foundational knowledge gained in CS107 and delves into advanced computer systems and program construction. It focuses on designing large systems, software that spans multiple machines, and parallel computing. The course aims to teach students the principles and practice of engineering of computer software and hardware systems.
+
+The course covers a broad range of topics including how your programs map onto the components of computer systems, understanding of program behavior and execution, understanding the designs and tradeoffs of large systems, writing software that spans multiple machines, and writing software that runs tasks in parallel on a single machine.
+
+The teaching style of this course is engaging and practical. The instructors guide the students to understand the numerous technical challenges and design principles in computer systems by going through the course materials and labs. Weekly labs let you add new features to the projects, which focus on enhancing students' practical skills. There are several labs during the whole semester which give you the chance to understand every aspect of the computer systems.
+
+In addition to the labs, the course also includes assignments that are designed to provide hands-on experience and deepen understanding of the course material. Each assignment has a complete framework for testing.
+
+## Course Resources
+
+- Course Website: <https://web.stanford.edu/class/archive/cs/cs110/cs110.1204/>
+- Lecture Videos: <https://www.youtube.com/playlist?list=PLai-xIlqf4JmTNR9aPCwIAOySs1GOm8sQ>
+- Text Book: <https://www.cs.sfu.ca/~ashriram/Courses/CS295/assets/books/CSAPP_2016.pdf>
+- Assignments: 7 labs (with solution) and 8 assignments, can be found on the course website.
+- Assignments solution: <https://github.com/xuzheng465/Stanford_CS110>


### PR DESCRIPTION
I added the course Stanford CS110: Principle of Computer Systems in the Operating Systems section. I don't know Chinese to add the Chinese version. Help me. Thank you!