### PR TITLE
enable last commit for each markdown file in gh page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,7 +119,10 @@ plugins:
       lang:
         - zh
         - en
-  - git-revision-date-localized
+  - git-revision-date-localized:
+     type: datetime 
+     fallback_to_build_date: false 
+ 
   - minify:
       minify_html: true
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,10 +119,7 @@ plugins:
       lang:
         - zh
         - en
-  - git-revision-date-localized:
-     type: datetime 
-     fallback_to_build_date: false 
- 
+  - git-revision-date:
   - minify:
       minify_html: true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mkdocs-material==9.5.2
 mkdocs-minify-plugin==0.7.1
-mkdocs-git-revision-date-localized-plugin==1.2.1
+mkdocs-git-revision-date-plugin
 jinja2==3.1.2
 mkdocs-static-i18n==1.2.0


### PR DESCRIPTION
现在是一个overall的last commit time，感觉没什么用，因为很多文件最后修改时间已经很久之前了。本地测试了一下，是成功的。