### PR TITLE
[FIX] Fix the course link for CS229

### DIFF
--- a/docs/机器学习/CS229.md
+++ b/docs/机器学习/CS229.md
@@ -12,7 +12,7 @@
 
 ## 课程资源
 
-- 课程网站：<http://cs229.stanford.edu/syllabus.html>
+- 课程网站：<http://cs229.stanford.edu>
 - 课程视频：<https://www.bilibili.com/video/BV1JE411w7Ub>
 - 课程教材：无，课程 notes 写得非常好
 - 课程作业：不对公众开放


### PR DESCRIPTION
原来链接不能用