### PR TITLE
[ENHANCE]Update CS61A resources

### DIFF
--- a/docs/编程入门/Python/CS61A.en.md
+++ b/docs/编程入门/Python/CS61A.en.md
@@ -24,12 +24,15 @@ Note: If you have no prior programming experience at all, getting started with C
 
 ## Course Resources
 
-- Course Website: [spring2024](https://inst.eecs.berkeley.edu/~cs61a/sp24), [fall2023](https://inst.eecs.berkeley.edu/~cs61a/fa23/), [spring2023](https://inst.eecs.berkeley.edu/~cs61a/sp23), [fall2022](https://inst.eecs.berkeley.edu/~cs61a/fall22)
-- Course Website (backup): [spring2022](https://cs61a.vercel.app/)
-- Recordings: 
-- Textbook: <https://www.composingprograms.com/>
-- Assignments: refer to the course website
+- [Course Website](https://cs61a.org)
+- Course Website (backup): [fall2024](https://insideempire.github.io/CS61A-Website-Archive/), [spring2022](https://cs61a.vercel.app/), [fall2022](https://web.archive.org/web/20220913035803/http://cs61a.org/), [fall2020](https://web.archive.org/web/20201219202644/https://cs61a.org/)
+- Recordings: [spring2024](https://www.bilibili.com/video/BV1sy411z7nA/), [fall2022](https://www.bilibili.com/video/BV1GK411Q7qp/), [fall2020](https://www.bilibili.com/video/BV1s3411G7yM/)
+- [Textbook](https://www.composingprograms.com/)
+- [Textbook(Chinese)](https://composingprograms.netlify.app/)
+- Assignments: [fall2024](https://github.com/InsideEmpire/CS61A-Assignments)
 
 ## Personal Resources
 
 All the resources and assignments used by @PKUFlyingPig in this course are maintained in [PKUFlyingPig/CS61A - GitHub](https://github.com/PKUFlyingPig/CS61A)
+
+All the resources and assignments used by @InsideEmpire in this course are maintained in [InsideEmpire/CS61A - GitHub](https://github.com/InsideEmpire/CS61A-PathwayToSuccess/)

--- a/docs/编程入门/Python/CS61A.md
+++ b/docs/编程入门/Python/CS61A.md
@@ -24,13 +24,15 @@ CS61B 和 CS61C 在本书中均有收录。
 
 ## 课程资源
 
-- 课程网站: [spring2024](https://inst.eecs.berkeley.edu/~cs61a/sp24), [fall2023](https://inst.eecs.berkeley.edu/~cs61a/fa23/), [spring2023](https://inst.eecs.berkeley.edu/~cs61a/sp23), [fall2022](https://inst.eecs.berkeley.edu/~cs61a/fall22)
-- 课程网站 (页面备份)：[spring2022](https://cs61a.vercel.app/)，[fall2022](https://web.archive.org/web/20220913035803/http://cs61a.org/), [fall2020](https://web.archive.org/web/20201219202644/https://cs61a.org/)
-- 课程视频: [fall2022](https://www.bilibili.com/video/BV1GK411Q7qp/), [fall2020](https://www.bilibili.com/video/BV1s3411G7yM/)
-- 课程教材: <https://www.composingprograms.com/>
-- 课程教材中文翻译：<https://composingprograms.netlify.app/>
-- 课程作业: 课程网站会有每个作业对应的文档链接以及代码框架的下载链接。
+- [课程网站](https://cs61a.org)
+- 课程网站 (页面备份): [fall2024](https://insideempire.github.io/CS61A-Website-Archive/), [spring2022](https://cs61a.vercel.app/), [fall2022](https://web.archive.org/web/20220913035803/http://cs61a.org/), [fall2020](https://web.archive.org/web/20201219202644/https://cs61a.org/)
+- 课程视频: [spring2024](https://www.bilibili.com/video/BV1sy411z7nA/), [fall2022](https://www.bilibili.com/video/BV1GK411Q7qp/), [fall2020](https://www.bilibili.com/video/BV1s3411G7yM/)
+- [课程教材](https://www.composingprograms.com/)
+- [课程教材中文翻译](https://composingprograms.netlify.app/)
+- 课程作业: [fall2024](https://github.com/InsideEmpire/CS61A-Assignments)
 
 ## 资源汇总
 
 @PKUFlyingPig 在学习这门课中用到的所有资源和作业实现都汇总在 [PKUFlyingPig/CS61A - GitHub](https://github.com/PKUFlyingPig/CS61A) 中。
+
+@InsideEmpire 在学习这门课中用到的所有资源和作业实现都汇总在 [InsideEmpire/CS61A - GitHub](https://github.com/InsideEmpire/CS61A-PathwayToSuccess/)


### PR DESCRIPTION
对CS61A.md的中英语标点混用做了修复
删除了现在已无法直接访问的原网址
添加了fall2024的课程网站备份和课程作业整合
添加了spring2024的课程视频