### PR TITLE
[FIX] Fix the textbook link for MIT18.330

### DIFF
--- a/docs/数学进阶/numerical.en.md
+++ b/docs/数学进阶/numerical.en.md
@@ -17,7 +17,7 @@ The designers of this course have also written an open source textbook for this 
 ## Course Resources
 
 - Course Website: <https://github.com/mitmath/18330>
-- Textbook: <https://fncbook.github.io/fnc/frontmatter.html>
+- Textbook: <https://fncbook.com>
 - Assignments: 10 problem sets
 
 ## Personal Resources

--- a/docs/数学进阶/numerical.md
+++ b/docs/数学进阶/numerical.md
@@ -17,7 +17,7 @@
 ## 课程资源
 
 - 课程网站：<https://github.com/mitmath/18330>
-- 课程教材：<https://fncbook.github.io/fnc/frontmatter.html>
+- 课程教材：<https://fncbook.com>
 - 课程作业：10 个 Julia 编程作业
 
 ## 资源汇总


### PR DESCRIPTION
修复issue #711 
更新`docs/数学进阶/numerical.md`与`docs/数学进阶/numerical.en.md`中的教材链接
