### PR TITLE
[UPDATE] Update CMU 15-418 course website and recordings

### DIFF
--- a/docs/并行与分布式系统/CS149.md
+++ b/docs/并行与分布式系统/CS149.md
@@ -14,8 +14,8 @@
 
 ## 课程资源
 
-- 课程网站：[CMU15418](http://15418.courses.cs.cmu.edu/spring2016/), [CS149](https://gfxcourses.stanford.edu/cs149/fall21)
-- 课程视频：[CMU15418](http://15418.courses.cs.cmu.edu/spring2016/lectures), [CS149](https://youtube.com/playlist?list=PLoROMvodv4rMp7MTFr4hQsDEcX7Bx6Odp&si=txtQiRDZ9ZZUzyRn)
+- 课程网站：[CMU15418](https://www.cs.cmu.edu/afs/cs/academic/class/15418-s18/www/index.html), [CS149](https://gfxcourses.stanford.edu/cs149/fall21)
+- 课程视频：[CMU15418](https://www.cs.cmu.edu/afs/cs/academic/class/15418-s18/www/schedule.html), [CS149](https://youtube.com/playlist?list=PLoROMvodv4rMp7MTFr4hQsDEcX7Bx6Odp&si=txtQiRDZ9ZZUzyRn)
 - 课程教材：无
 - 课程作业：<https://gfxcourses.stanford.edu/cs149/fall21>，5 个编程作业
 


### PR DESCRIPTION
Update CMU 15-418 course website and recordings.

Problem: The previous course website and videos are no longer accessible.
![image](https://github.com/user-attachments/assets/7d4bd0ef-427c-4b7c-bdc2-61b177fd8eb9)

Update: Now they have been updated to the [sp18 version of the course](https://www.cs.cmu.edu/afs/cs/academic/class/15418-s18/www/index.html) website and corresponding [videos](https://www.cs.cmu.edu/afs/cs/academic/class/15418-s18/www/schedule.html).