### PR TITLE
[Update] Add Stanford CS231n spring 2025 (latest) lecture videos link

### DIFF
--- a/docs/深度学习/CS231.en.md
+++ b/docs/深度学习/CS231.en.md
@@ -13,6 +13,6 @@ Stanford's CV introductory class, led by the giant of the computer field, Fei-Fe
 ## Course Resources
 
 - Course Website：<http://cs231n.stanford.edu/>
-- Course Video：<https://www.bilibili.com/video/BV1nJ411z7fe>
+- Course Video：[spring 2017 Bilibili (Classic)](https://www.bilibili.com/video/BV1nJ411z7fe), [spring 2025 YouTube (Latest)](https://www.youtube.com/playlist?list=PLoROMvodv4rOmsNzYBMe0gJY2XS8AQg16)
 - Course Materials: None
 - Coursework：<http://cs231n.stanford.edu/schedule.html>，3 Programming Assignments

--- a/docs/深度学习/CS231.md
+++ b/docs/深度学习/CS231.md
@@ -13,6 +13,6 @@ Stanford 的 CV 入门课，由计算机领域的巨佬李飞飞院士领衔教�
 ## 课程资源
 
 - 课程网站：<http://cs231n.stanford.edu/>
-- 课程视频：<https://www.bilibili.com/video/BV1nJ411z7fe>
+- 课程视频：[spring 2017 Bilibili](https://www.bilibili.com/video/BV1nJ411z7fe), [spring 2025 YouTube (最新)](https://www.youtube.com/playlist?list=PLoROMvodv4rOmsNzYBMe0gJY2XS8AQg16)
 - 课程教材：无
 - 课程作业：<http://cs231n.stanford.edu/schedule.html>，3个编程作业


### PR DESCRIPTION
- Add the [YouTube link](https://www.youtube.com/playlist?list=PLoROMvodv4rOmsNzYBMe0gJY2XS8AQg16) of the newest CS231n Spring 2025 lecture videos officially uploaded by [Stanford Online](https://www.youtube.com/@stanfordonline)
- Update both Chinese and English versions

The newest videos are not available on the [official website](https://cs231n.stanford.edu), and the [spring 2017 version](https://www.bilibili.com/video/BV1nJ411z7fe/) seems to be a little bit outdated. 
It is necessary to add the newest one to the course page without removing the classic version.

Here's the change
```git
in "CS231.md"
-- 课程视频：<https://www.bilibili.com/video/BV1nJ411z7fe>
+- 课程视频：[spring 2017 Bilibili](https://www.bilibili.com/video/BV1nJ411z7fe), [spring 2025 YouTube (最新)](https://www.youtube.com/playlist?list=PLoROMvodv4rOmsNzYBMe0gJY2XS8AQg16)

in "CS231.en.md"
-- Course Video：<https://www.bilibili.com/video/BV1nJ411z7fe>
+- Course Video：[spring 2017 Bilibili (Classic)](https://www.bilibili.com/video/BV1nJ411z7fe), [spring 2025 YouTube (Latest)](https://www.youtube.com/playlist?list=PLoROMvodv4rOmsNzYBMe0gJY2XS8AQg16)
```