### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
 


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/setup-python` from `v2` to `v6` in `.github/workflows/ci.yml`
- Updated `actions/checkout` from `v2` to `v6` in `.github/workflows/ci.yml`
