### PR TITLE
[Update] update MIT-missing-semester lecture recordings link with 2026 version

### DIFF
--- a/docs/编程入门/MIT-Missing-Semester.en.md
+++ b/docs/编程入门/MIT-Missing-Semester.en.md
@@ -13,5 +13,5 @@ Just as the course name indicated, this course will teach the missing things in 
 ## Course Resources
 
 - Course Website: <https://missing.csail.mit.edu/>
-- Recordings: <https://www.youtube.com/playlist?list=PLyzOVJj3bHQuloKGG59rS43e29ro7I57J>
+- Recordings: [IAP 2020](https://www.youtube.com/playlist?list=PLyzOVJj3bHQuloKGG59rS43e29ro7I57J), [IAP 2026](https://www.youtube.com/playlist?list=PLyzOVJj3bHQunmnnTXrNbZnBaCA-ieK4L) in YouTube
 - Assignments: Some exercises after each lecture, refer to the course website.

--- a/docs/编程入门/MIT-Missing-Semester.md
+++ b/docs/编程入门/MIT-Missing-Semester.md
@@ -15,7 +15,7 @@
 
 - 课程网站：<https://missing.csail.mit.edu/2020/>
 - 课程中文网站: <https://missing-semester-cn.github.io/>
-- 课程视频：<https://www.youtube.com/playlist?list=PLyzOVJj3bHQuloKGG59rS43e29ro7I57J>
+- 课程视频：[IAP 2020](https://www.youtube.com/playlist?list=PLyzOVJj3bHQuloKGG59rS43e29ro7I57J), [IAP 2026](https://www.youtube.com/playlist?list=PLyzOVJj3bHQunmnnTXrNbZnBaCA-ieK4L) in YouTube
 - 课程中文字幕视频：
     - Missing_Semi_中译组（未完结）：<https://space.bilibili.com/1010983811?spm_id_from=333.337.search-card.all.click>
     - 刘黑黑a（已完结）：<https://space.bilibili.com/518734451?spm_id_from=333.337.search-card.all.click>


### PR DESCRIPTION
Recently the MIT-Missing-Semester course released its [2026 version](https://missing.csail.mit.edu/), which, compared with the [2020 version](https://missing.csail.mit.edu/2020/), introduces the use of AI-enhanced tools and workflows. 

The course lecture videos are available at [youtube.com/@MissingSemester/IAP2026](https://www.youtube.com/playlist?list=PLyzOVJj3bHQunmnnTXrNbZnBaCA-ieK4L), and I requested that this link be added to [csdiy.wiki](https://csdiy.wiki/%E7%BC%96%E7%A8%8B%E5%85%A5%E9%97%A8/MIT-Missing-Semester/). 

The official site describes the updates in the 2026 content compared with the 2020 versoin as follows:

> These days, many aspects of software engineering are also in flux through the introduction of AI-enabled and AI-enhanced tools and workflows. When used appropriately and with awareness of their shortcomings, these can often provide significant benefits to CS practitioners and are thus worth developing working knowledge of. Since AI is a cross-functional enabling technology, there is not a standalone AI lecture; we’ve instead folded the use of the latest applicable AI tools and techniques into each lecture directly.

* update MIT-Missing-Semester.md
* update MIT-Missing-Semester.en.md