### PR TITLE
[UPDATE]: Add CS61C Fa24 Course Website Backup and Recording

### DIFF
--- a/docs/体系结构/CS61C.en.md
+++ b/docs/体系结构/CS61C.en.md
@@ -20,6 +20,7 @@ In a word, this is the best computer architecture course I have ever taken.
 - Course Website (Backup): [Fa24-WayBack Machine](https://web.archive.org/web/20241219154359/https://cs61c.org/fa24/), [Fa24-Backup](https://z0z0r4.github.io/cs61c-fa24-website/), [Fa20-WayBack Machine](https://web.archive.org/web/20220120134001/https://inst.eecs.berkeley.edu/~cs61c/fa20/), [Fa20-Backup](https://www.learncs.site/docs/curriculum-resource/cs61c/syllabus)
 - Recordings: [Fa24-Bilibili](https://www.bilibili.com/video/BV1eGwFeQEfm), [Su20-Bilibili](https://www.bilibili.com/video/BV1fC4y147iZ), [Su20-Youtube](https://youtube.com/playlist?list=PLDoI-XvXO0aqgoMQvogzmf7CKiSMSUS3M&si=62aaH5a_PMGrAT2Y), [Fa20-Bilibili](https://www.bilibili.com/video/BV17b42177VG), [Fa20-Youtube](https://youtube.com/playlist?list=PL0j-r-omG7i0-mnsxN5T4UcVS1Di0isqf&si=CG1EjQiPcw7r7Vs4)
 - Assignments: [Fa20-Backup](https://github.com/InsideEmpire/CS61C-Assignment#)
+- Course Notes: [CS 61C: Course Notes](https://notes.cs61c.org/)
 
 ## Personal Resources
 

--- a/docs/体系结构/CS61C.en.md
+++ b/docs/体系结构/CS61C.en.md
@@ -17,8 +17,8 @@ In a word, this is the best computer architecture course I have ever taken.
 ## Course Resources
 
 - [Course Website](https://cs61c.org/)
-- Course Website (Backup): [Fa24-WayBack Machine](https://web.archive.org/web/20241219154359/https://cs61c.org/fa24/), [Fa20-WayBack Machine](https://web.archive.org/web/20220120134001/https://inst.eecs.berkeley.edu/~cs61c/fa20/), [Fa20-Backup](https://www.learncs.site/docs/curriculum-resource/cs61c/syllabus)
-- Recordings: [Su20-Bilibili](https://www.bilibili.com/video/BV1fC4y147iZ/?share_source=copy_web&vd_source=7c3823b46a52fbbef42b79e01d55c300), [Su20-Youtube](https://youtube.com/playlist?list=PLDoI-XvXO0aqgoMQvogzmf7CKiSMSUS3M&si=62aaH5a_PMGrAT2Y), [Fa20-Bilibili](https://www.bilibili.com/video/BV17b42177VG/?share_source=copy_web&vd_source=7c3823b46a52fbbef42b79e01d55c300), [Fa20-Youtube](https://youtube.com/playlist?list=PL0j-r-omG7i0-mnsxN5T4UcVS1Di0isqf&si=CG1EjQiPcw7r7Vs4)
+- Course Website (Backup): [Fa24-WayBack Machine](https://web.archive.org/web/20241219154359/https://cs61c.org/fa24/), [Fa24-Backup](https://z0z0r4.github.io/cs61c-fa24-website/), [Fa20-WayBack Machine](https://web.archive.org/web/20220120134001/https://inst.eecs.berkeley.edu/~cs61c/fa20/), [Fa20-Backup](https://www.learncs.site/docs/curriculum-resource/cs61c/syllabus)
+- Recordings: [Fa24-Bilibili](https://www.bilibili.com/video/BV1eGwFeQEfm), [Su20-Bilibili](https://www.bilibili.com/video/BV1fC4y147iZ), [Su20-Youtube](https://youtube.com/playlist?list=PLDoI-XvXO0aqgoMQvogzmf7CKiSMSUS3M&si=62aaH5a_PMGrAT2Y), [Fa20-Bilibili](https://www.bilibili.com/video/BV17b42177VG), [Fa20-Youtube](https://youtube.com/playlist?list=PL0j-r-omG7i0-mnsxN5T4UcVS1Di0isqf&si=CG1EjQiPcw7r7Vs4)
 - Assignments: [Fa20-Backup](https://github.com/InsideEmpire/CS61C-Assignment#)
 
 ## Personal Resources

--- a/docs/体系结构/CS61C.md
+++ b/docs/体系结构/CS61C.md
@@ -23,6 +23,7 @@
 - 课程网站 (页面备份): [Fa24-WayBack Machine](https://web.archive.org/web/20241219154359/https://cs61c.org/fa24/), [Fa24-备份](https://z0z0r4.github.io/cs61c-fa24-website/), [Fa20-WayBack Machine](https://web.archive.org/web/20220120134001/https://inst.eecs.berkeley.edu/~cs61c/fa20/), [Fa20-备份](https://www.learncs.site/docs/curriculum-resource/cs61c/syllabus)
 - 课程视频: [Fa24-Bilibili](https://www.bilibili.com/video/BV1eGwFeQEfm), [Su20-Bilibili](https://www.bilibili.com/video/BV1fC4y147iZ/?share_source=copy_web&vd_source=7c3823b46a52fbbef42b79e01d55c300), [Su20-Youtube](https://youtube.com/playlist?list=PLDoI-XvXO0aqgoMQvogzmf7CKiSMSUS3M&si=62aaH5a_PMGrAT2Y), [Fa20-Bilibili](https://www.bilibili.com/video/BV17b42177VG/?share_source=copy_web&vd_source=7c3823b46a52fbbef42b79e01d55c300), [Fa20-Youtube](https://youtube.com/playlist?list=PL0j-r-omG7i0-mnsxN5T4UcVS1Di0isqf&si=CG1EjQiPcw7r7Vs4)
 - 课程作业: [Fa20-备份](https://github.com/InsideEmpire/CS61C-Assignment#)
+- 课程笔记: [CS 61C: Course Notes](https://notes.cs61c.org/)
 
 ## 资源汇总
 

--- a/docs/体系结构/CS61C.md
+++ b/docs/体系结构/CS61C.md
@@ -20,8 +20,8 @@
 ## 课程资源
 
 - [课程网站](https://cs61c.org/)
-- 课程网站 (页面备份): [Fa24-WayBack Machine](https://web.archive.org/web/20241219154359/https://cs61c.org/fa24/), [Fa20-WayBack Machine](https://web.archive.org/web/20220120134001/https://inst.eecs.berkeley.edu/~cs61c/fa20/), [Fa20-备份](https://www.learncs.site/docs/curriculum-resource/cs61c/syllabus)
-- 课程视频: [Su20-Bilibili](https://www.bilibili.com/video/BV1fC4y147iZ/?share_source=copy_web&vd_source=7c3823b46a52fbbef42b79e01d55c300), [Su20-Youtube](https://youtube.com/playlist?list=PLDoI-XvXO0aqgoMQvogzmf7CKiSMSUS3M&si=62aaH5a_PMGrAT2Y), [Fa20-Bilibili](https://www.bilibili.com/video/BV17b42177VG/?share_source=copy_web&vd_source=7c3823b46a52fbbef42b79e01d55c300), [Fa20-Youtube](https://youtube.com/playlist?list=PL0j-r-omG7i0-mnsxN5T4UcVS1Di0isqf&si=CG1EjQiPcw7r7Vs4)
+- 课程网站 (页面备份): [Fa24-WayBack Machine](https://web.archive.org/web/20241219154359/https://cs61c.org/fa24/), [Fa24-备份](https://z0z0r4.github.io/cs61c-fa24-website/), [Fa20-WayBack Machine](https://web.archive.org/web/20220120134001/https://inst.eecs.berkeley.edu/~cs61c/fa20/), [Fa20-备份](https://www.learncs.site/docs/curriculum-resource/cs61c/syllabus)
+- 课程视频: [Fa24-Bilibili](https://www.bilibili.com/video/BV1eGwFeQEfm), [Su20-Bilibili](https://www.bilibili.com/video/BV1fC4y147iZ/?share_source=copy_web&vd_source=7c3823b46a52fbbef42b79e01d55c300), [Su20-Youtube](https://youtube.com/playlist?list=PLDoI-XvXO0aqgoMQvogzmf7CKiSMSUS3M&si=62aaH5a_PMGrAT2Y), [Fa20-Bilibili](https://www.bilibili.com/video/BV17b42177VG/?share_source=copy_web&vd_source=7c3823b46a52fbbef42b79e01d55c300), [Fa20-Youtube](https://youtube.com/playlist?list=PL0j-r-omG7i0-mnsxN5T4UcVS1Di0isqf&si=CG1EjQiPcw7r7Vs4)
 - 课程作业: [Fa20-备份](https://github.com/InsideEmpire/CS61C-Assignment#)
 
 ## 资源汇总


### PR DESCRIPTION
https://z0z0r4.github.io/cs61c-fa24-website/

爬了一下时光机上面的 Fa24，详见 https://github.com/z0z0r4/cs61c-fa24-website，丢到 pages 上面了，方便使用 

我自己现在开始学 CS61C，可能逐渐发现备份中有缺失，可以先不合并

以及发现有 Fa24 的课程视频，但是油管找不到 https://www.bilibili.com/video/BV1eGwFeQEfm