### PR TITLE
fix: update MIT calculus course links

### DIFF
--- a/docs/数学基础/MITmaths.en.md
+++ b/docs/数学基础/MITmaths.en.md
@@ -14,7 +14,7 @@ In addition to the course materials, the famous Youtuber **3Blue1Brown**'s video
 
 ## Course Resources
 
-- Course Website: [18.01](https://ocw.mit.edu/courses/mathematics/18-01sc-single-variable-calculus-fall-2010/syllabus/), [18.02](https://ocw.mit.edu/courses/mathematics/18-02sc-multivariable-calculus-fall-2010/)
+- Course Website: [18.01](https://ocw.mit.edu/courses/18-01sc-single-variable-calculus-fall-2010/), [18.02](https://ocw.mit.edu/courses/18-02sc-multivariable-calculus-fall-2010/)
 - Recordings: refer to course website
 - Textbook: refer to course website
 - Assignments: refer to course website

--- a/docs/数学基础/MITmaths.md
+++ b/docs/数学基础/MITmaths.md
@@ -14,7 +14,7 @@ MIT 的微积分课由 MIT18.01: Single Variable Calculus 和 MIT18.02: Multivar
 
 ## 课程资源
 
-- 课程网站：[18.01](https://ocw.mit.edu/courses/mathematics/18-01sc-single-variable-calculus-fall-2010/syllabus/), [18.02](https://ocw.mit.edu/courses/mathematics/18-02sc-multivariable-calculus-fall-2010/)
+- 课程网站：[18.01](https://ocw.mit.edu/courses/18-01sc-single-variable-calculus-fall-2010/), [18.02](https://ocw.mit.edu/courses/18-02sc-multivariable-calculus-fall-2010/)
 - 课程视频：参见课程网站
 - 课程教材：参见课程 notes
 - 课程作业：书面作业及答案参见课程网站


### PR DESCRIPTION
修复 MIT OpenCourseWare 的课程链接。

- 将 18.01 更新为当前可用的课程主页地址
- 将 18.02 同步为当前规范路径

原链接使用了已失效的旧版 OCW 路径。