### PR TITLE
[README] Fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=PKUFlyingPig/cs-self-learning&type=Timeline)](https://star-history.com/#PKUFlyingPig/cs-self-learning&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=PKUFlyingPig/cs-self-learning&type=Timeline)](https://star-history.dera.page/#PKUFlyingPig/cs-self-learning&Timeline)
 
 ## ✨ 鸣谢
 


### PR DESCRIPTION
The Star History chart shown in the README is currently broken and no longer displays for visitors. This change fixes the chart so the project's stargazer trend is visible again.