### PR TITLE
[UPDATE] Add optional machine-coding practice to CS571

### DIFF
--- a/docs/Web开发/CS571.en.md
+++ b/docs/Web开发/CS571.en.md
@@ -23,3 +23,7 @@ According to the official website, CS 571 is open to everyone. You can request a
 - Course Website: <https://cs571.org>
 - Course Videos: Refer to the links labeled "R" on the course website.
 - Course Assignments: Refer to the course website for more information.
+
+## Additional Practice
+
+- [FrontendAtlas frontend machine-coding practice](https://frontendatlas.com/machine-coding): Optional browser-based practice covering React UI, asynchronous widgets, forms, tables, keyboard interaction, and accessibility checks.

--- a/docs/Web开发/CS571.md
+++ b/docs/Web开发/CS571.md
@@ -23,3 +23,7 @@
 - 课程网站：<https://cs571.org>
 - 课程视频：请参考课程网站上标有“R”的链接
 - 课程作业：请参考课程网站上的相关信息
+
+## 补充练习
+
+- [FrontendAtlas 前端 Machine Coding 练习](https://frontendatlas.com/machine-coding)：可作为浏览器端补充练习，涵盖 React UI、异步组件、表单、表格、键盘交互与无障碍检查。


### PR DESCRIPTION
## Summary
- add FrontendAtlas as optional machine-coding practice for CS571 learners
- keep Chinese and English course pages aligned

## Rationale
CS571 emphasizes hands-on React UI development. The linked practice hub covers asynchronous UI, forms, tables, keyboard interaction, and accessibility checks, complementing the course assignments without replacing official materials.

## Disclosure
I am affiliated with FrontendAtlas. This is proposed only as an optional supplement, not as an official CS571 resource. FrontendAtlas is freemium; the public hub and previews are available, while some full editor/solution content requires premium access. I am happy to revise or remove it if it does not meet the project’s curation criteria.

## Validation
- [x] Updated both language files
- [x] Checked mixed Chinese/English typography
- [ ] `mkdocs build --strict` not run locally
- [x] Verified target loads